### PR TITLE
Support highlightPerDragEnabled on LineChart

### DIFF
--- a/mp_chart/lib/mp/chart/bar_line_scatter_candle_bubble_chart.dart
+++ b/mp_chart/lib/mp/chart/bar_line_scatter_candle_bubble_chart.dart
@@ -133,6 +133,15 @@ class BarLineScatterCandleBubbleState<T extends BarLineScatterCandleBubbleChart>
 
   @override
   void onMoveUpdate(OpsMoveUpdateDetails details) {
+    if (widget.controller.painter.highlightPerDragEnabled) {
+      final highlighted = widget.controller.painter.getHighlightByTouchPoint(
+          details.localPoint.dx, details.localPoint.dy);
+      if (highlighted?.equalTo(lastHighlighted) == false) {
+        lastHighlighted = HighlightUtils.performHighlight(
+            widget.controller.painter, highlighted, lastHighlighted);
+        setStateIfNotDispose();
+      }
+    }
     var dx = details.localPoint.dx - _curX;
     var dy = details.localPoint.dy - _curY;
     if (widget.controller.painter.dragYEnabled &&


### PR DESCRIPTION
If highlightPerDragEnabled frag is true on LineChat, you can move marker by drag.