### PR TITLE
Add null check for highlight on tap chart

### DIFF
--- a/mp_chart/lib/mp/painter/painter.dart
+++ b/mp_chart/lib/mp/painter/painter.dart
@@ -395,7 +395,7 @@ abstract class ChartPainter<T extends ChartData<IDataSet<Entry>>>
   /// @param y
   /// @return
   Highlight getHighlightByTouchPoint(double x, double y) {
-    if (_data == null) {
+    if (_data == null || highlighter == null) {
       return null;
     } else {
       return highlighter.getHighlight(x, y);


### PR DESCRIPTION
I/flutter (30905): Handler: "onTapDown"
I/flutter (30905): Recognizer:
I/flutter (30905):   TapGestureRecognizer#0c654
I/flutter (30905): ════════════════════════════════════════════════════════════════════════════════════════════════════
I/flutter (30905): ══╡ EXCEPTION CAUGHT BY GESTURE ╞═══════════════════════════════════════════════════════════════════
I/flutter (30905): The following NoSuchMethodError was thrown while handling a gesture:
I/flutter (30905): The method 'getHighlight' was called on null.
I/flutter (30905): Receiver: null
I/flutter (30905): Tried calling: getHighlight(274.0, 97.58333333333331)
I/flutter (30905): 
I/flutter (30905): When the exception was thrown, this was the stack:
I/flutter (30905): #0      Object.noSuchMethod (dart:core-patch/object_patch.dart:51:5)
I/flutter (30905): #1      ChartPainter.getHighlightByTouchPoint (package:mp_chart/mp/painter/painter.dart:401:26)
I/flutter (30905): #2      BarLineChartBasePainter.getDataSetByTouchPoint (package:mp_chart/mp/painter/bar_line_chart_painter.dart:757:19)
I/flutter (30905): #3      BarLineScatterCandleBubbleState.onTapDown (package:mp_chart/mp/chart/bar_line_scatter_candle_bubble_chart.dart:59:56)
I/flutter (30905): #4      ChartState.build.<anonymous closure> (package:mp_chart/mp/chart/chart.dart:84:25)
I/flutter (30905): #5      OptimizedGestureDetector.build.<anonymous closure> (package:optimized_gesture_detector/optimized_gesture_detector.dart:131:27)
I/flutter (30905): #6      TapGestureRecognizer.handleTapDown.<anonymous closure> (package:flutter/src/gestures/tap.dart:502:60)
I/flutter (30905): #7      GestureRecognizer.invokeCallback (package:flutter/src/gestures/recognizer.dart:184:24)
I/flutter (30905): #8      TapGestureRecognizer.handleTapDown (package:flutter/src/gestures/tap.dart:502:11)
I/flutter (30905): #9      BaseTapGestureRecognizer._checkDown (package:flutter/src/gestures/tap.dart:276:5)
I/flutter (30905): #10     BaseTapGestureRecognizer.acceptGesture (package:flutter/src/gestures/tap.dart:254:7)
I/flutter (30905): #11     GestureArenaManager.sweep (package:flutter/src/gestures/arena.dart:158:27)
I/flutter (30905): #12     GestureBinding.handleEvent (package:flutter/src/gestures/binding.dart:224:20)
I/flutter (30905): #13     GestureBinding.dispatchEvent (package:flutter/src/gestures/binding.dart:200:22)
I/flutter (30905): #14     GestureBinding._handlePointerEvent (package:flutter/src/gestures/binding.dart:158:7)
I/flutter (30905): #15     GestureBinding._flushPointerEventQueue (package:flutter/src/gestures/binding.dart:104:7)
I/flutter (30905): #16     GestureBinding._handlePointerDataPacket (package:flutter/src/gestures/binding.dart:88:7)
I/flutter (30905): #20     _invoke1 (dart:ui/hooks.dart:267:10)
I/flutter (30905): #21     _dispatchPointerDataPacket (dart:ui/hooks.dart:176:5)
I/flutter (30905): (elided 3 frames from dart:async)


---
If chart data is null or empty, above exception is happened.

getHighlight is of IHighlighter and highlighter is set by initDefaultWithData.
https://github.com/SunPointed/MPFlutterChart/blob/master/mp_chart/lib/mp/painter/bar_line_chart_painter.dart#L246

initDefaultWithData is not called if chart data is null or empty.
https://github.com/SunPointed/MPFlutterChart/blob/master/mp_chart/lib/mp/painter/painter.dart#L168

My change is add to null check for getHighlightByTouchPoint.
Please check it. Thank you very much.