### PR TITLE
Pie Chart Center Text fontFamily and fontWeight bug fix and new options centerTextColor and centerTextSize

### DIFF
--- a/mp_chart/lib/mp/chart/chart.dart
+++ b/mp_chart/lib/mp/chart/chart.dart
@@ -1,12 +1,8 @@
-import 'dart:io';
-import 'dart:typed_data';
-
 import 'package:flutter/widgets.dart';
 import 'package:image_gallery_saver/image_gallery_saver.dart';
 import 'package:mp_chart/mp/controller/controller.dart';
 import 'package:optimized_gesture_detector/details.dart';
 import 'package:optimized_gesture_detector/optimized_gesture_detector.dart';
-import 'package:path_provider/path_provider.dart';
 import 'package:screenshot/screenshot.dart';
 
 abstract class Chart<C extends Controller> extends StatefulWidget {
@@ -35,22 +31,9 @@ abstract class ChartState<T extends Chart> extends State<T> {
   void capture() async {
     if (isCapturing) return;
     isCapturing = true;
-    String directory = "";
-    if (Platform.isAndroid) {
-      directory = (await getExternalStorageDirectory()).path;
-    } else if (Platform.isIOS) {
-      directory = (await getApplicationDocumentsDirectory()).path;
-    } else {
-      return;
-    }
 
-    String fileName = DateTime.now().toIso8601String();
-    String path = '$directory/$fileName.png';
-    _screenshotController.capture(path: path, pixelRatio: 3.0).then((imgFile) {
-      ImageGallerySaver.saveImage(Uint8List.fromList(imgFile.readAsBytesSync()))
-          .then((value) {
-        imgFile.delete();
-      });
+    _screenshotController.capture(pixelRatio: 3.0).then((imgFile) {
+      ImageGallerySaver.saveImage(imgFile);
       isCapturing = false;
     }).catchError((error) {
       isCapturing = false;

--- a/mp_chart/lib/mp/controller/pie_chart_controller.dart
+++ b/mp_chart/lib/mp/controller/pie_chart_controller.dart
@@ -30,6 +30,8 @@ class PieChartController extends PieRadarController<PieChartPainter> {
   TypeFace entryLabelTypeface;
   Color backgroundColor;
   Color holeColor;
+  Color centerTextColor;
+  double centerTextSize;
 
   PieChartController({
     this.drawEntryLabels = true,
@@ -50,6 +52,8 @@ class PieChartController extends PieRadarController<PieChartPainter> {
     this.entryLabelTypeface,
     this.backgroundColor,
     this.holeColor = ColorUtils.WHITE,
+    this.centerTextColor,
+    this.centerTextSize,
     IMarker marker,
     Description description,
     XAxisSettingFunction xAxisSettingFunction,
@@ -156,6 +160,8 @@ class PieChartController extends PieRadarController<PieChartPainter> {
       minAngleForSlices,
       backgroundColor,
       holeColor,
+      centerTextColor,
+      centerTextSize,
     );
   }
 

--- a/mp_chart/lib/mp/core/render/pie_chart_renderer.dart
+++ b/mp_chart/lib/mp/core/render/pie_chart_renderer.dart
@@ -832,7 +832,10 @@ class PieChartRenderer extends DataRenderer {
       c.save();
 
       _centerTextPaint = PainterUtils.create(_centerTextPaint, centerText,
-          ColorUtils.BLACK, Utils.convertDpToPixel(12));
+          _painter.centerTextColor ?? ColorUtils.BLACK,
+          _painter.centerTextSize ?? Utils.convertDpToPixel(12),
+          fontFamily: _painter.centerTextTypeface?.fontFamily,
+          fontWeight: _painter.centerTextTypeface?.fontWeight);
       _centerTextPaint.layout();
       _centerTextPaint.paint(
           c,

--- a/mp_chart/lib/mp/core/utils/painter_utils.dart
+++ b/mp_chart/lib/mp/core/utils/painter_utils.dart
@@ -12,7 +12,7 @@ abstract class PainterUtils {
     }
 
     if (painter.text != null && (painter.text is TextSpan)) {
-      var preText = painter.text.text;
+      var preText = (painter.text as TextSpan).text;
       var preColor = painter.text.style.color;
       preColor = preColor == null ? ColorUtils.BLACK : preColor;
       var preFontSize = painter.text.style.fontSize;

--- a/mp_chart/lib/mp/painter/pie_chart_painter.dart
+++ b/mp_chart/lib/mp/painter/pie_chart_painter.dart
@@ -77,6 +77,15 @@ class PieChartPainter extends PieRadarChartPainter<PieData> {
   MPPointF _centerTextOffset;
 
   TypeFace _centerTextTypeface;
+  TypeFace get centerTextTypeface => _centerTextTypeface;
+
+  /// Center text color
+  final Color _centerTextColor;
+  Color get centerTextColor => _centerTextColor;
+
+  /// Center text font size
+  final double _centerTextSize;
+  double get centerTextSize => _centerTextSize;
   TypeFace _entryLabelTypeface;
 
   PieChartPainter(
@@ -121,7 +130,9 @@ class PieChartPainter extends PieRadarChartPainter<PieData> {
       double maxAngle,
       double minAngleForSlices,
       Color backgroundColor,
-      Color holeColor)
+      Color holeColor,
+      Color centerTextColor,
+      double centerTextSize)
       : _drawEntryLabels = drawEntryLabels,
         _drawHole = drawHole,
         _drawSlicesUnderHole = drawSlicesUnderHole,
@@ -139,6 +150,8 @@ class PieChartPainter extends PieRadarChartPainter<PieData> {
         _centerTextTypeface = centerTextTypeface,
         _entryLabelTypeface = entryLabelTypeface,
         _holeColor = holeColor,
+        _centerTextColor = centerTextColor,
+        _centerTextSize = centerTextSize,
         super(
             data,
             animator,

--- a/mp_chart/pubspec.yaml
+++ b/mp_chart/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
 dependencies:
   intl: ^0.17.0
   path_provider: ^2.0.1
-  screenshot: ^0.3.0
-  path_drawing: ^0.5.0-nullsafety.0
-  image_gallery_saver: ^1.6.8
+  screenshot: ^1.0.0-nullsafety.1
+  path_drawing: ^0.5.0
+  image_gallery_saver: ^1.6.9
   optimized_gesture_detector: ^0.0.6
   vector_math: ^2.1.0
   flutter:

--- a/mp_chart/pubspec.yaml
+++ b/mp_chart/pubspec.yaml
@@ -8,13 +8,13 @@ environment:
   sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
-  intl: ^0.17.0-nullsafety.1
-  path_provider: ^1.1.0
-  screenshot: ^0.1.1
-  path_drawing: ^0.4.1
-  image_gallery_saver: ^1.2.2
+  intl: ^0.17.0
+  path_provider: ^2.0.1
+  screenshot: ^0.3.0
+  path_drawing: ^0.5.0-nullsafety.0
+  image_gallery_saver: ^1.6.8
   optimized_gesture_detector: ^0.0.6
-  vector_math: ^2.0.8
+  vector_math: ^2.1.0
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
- Pie Chart Center Text fontFamily and fontWeight were not working, fixed the bug, now below code should set the font
`PieChartController(centerTextTypeface: TypeFace(fontFamily: 'Roboto', fontWeight: FontWeight.bold));`

- Pie Chart Center Text added new options to customize centerTextColor and centerTextSize, current version was always painting text in Black with 12 font size. After this change if values are provided using PieChartController these will be used, if these are null then current implementation will work with backward compatibility
`PieChartController(centerText: '2020',centerTextColor: AppColors.blue, centerTextSize: 20);`
![Change details](https://user-images.githubusercontent.com/1186833/98878157-96d7b700-2482-11eb-9ca7-3ad2668b0ad2.png)

@SunPointed If you like the changes, feel free to pull